### PR TITLE
Use keyword.proto instead of keyword.operator.proto

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "proto",
     "displayName": "Protobuf support",
     "description": "Protobuf support (.proto file syntax highlighting)",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "publisher": "peterj",
     "license": "SEE LICENSE IN LICENSE.md",
     "icon": "images/protobuficon.svg",

--- a/syntaxes/proto.tmLanguage
+++ b/syntaxes/proto.tmLanguage
@@ -16,7 +16,7 @@
 			<key>match</key>
 			<string>\b(default|enum|extend|extensions|message|option|optional|package|rpc|repeated|required|returns|service)\b</string>
 			<key>name</key>
-			<string>keyword.operator.proto</string>
+			<string>keyword.proto</string>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
Semantically, `default|enum|extend|extensions|message|option|optional|package|rpc|repeated|required|returns|service` are more like keywords than operators.

Also, the default Dark+ and Light+ themes of vscode do not differentiate operators from other text, so colors are lost when these words are operators, whereas coloring is gained when these are keywords.